### PR TITLE
Pulse 6005 - Add getAgents Support To Dallinger

### DIFF
--- a/dallinger/pulse.py
+++ b/dallinger/pulse.py
@@ -100,8 +100,24 @@ class PulseService:
 
         return True
 
-    def get_agents(self):
-        return ['ecbd08d2-6fdc-430b-abac-7b1827ae4433']
+    def get_agents(self, location):
+        resp = self.api_get('agent', {'location': location})
+
+        if resp.get('response', {}).get('agents') is None:
+            raise Exception("Could not get pulse recruits")
+
+        resp_agents = resp.get('response', {}).get('agents')
+        agents = []
+
+        for agent in resp_agents:
+            if agent.get('participatedIn') == self.project_id:
+                logger.debug("Agent {} already participated, skipping".format(agent.get('id')))
+            else:
+                logger.debug("Got agent {}".format(agent.get('id')))
+                agents.append(agent.get('id'))
+
+        return agents
+
 
     def recruit(self, agent, url):
         """ Send notification to contacts that the experiment is live """

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -681,7 +681,7 @@ class PulseRecruiter(Recruiter):
     def recruit(self, n=1):
         """Recruit n new participants to the queue"""
 
-        agents = self.pulse_service.get_agents()
+        agents = self.pulse_service.get_agents(self.config.get('pulse_location'))
 
         for agent in agents:
             experiment_url = '{}/ad?recruiter={}&hitId={}&assignmentId={}&workerId={}'.format(


### PR DESCRIPTION
## What's New?

The getAgents() call has been added to Dallinger. 

## Testing

- Setup a PAPI application
- Create an agent:
```
{
            "flow": "340a8260-830b-4868-a8af-1f13c1ce081b",
            "flowTime": "2018-07-24T01:00:00.000Z",
            "group": "TestGroup",
            "blocked": false,
            "stopped": false,
            "name": "T1 Test",
            "firstName": "T1",
            "lastName": "Test",
            "email": "t1.test@example.com",
            "website": "www.t1test.com",
            "location": "http://sws.geonames.org/226074/",
            "language": "eng",
            "age": 18,
            "gender": "male",
            "phone": "11234567890",
            "accounts": [
            ]
        }
```
- Configure a Dallinger demo with the Pulse recruiter. Remove the mturk recruiter section and add the following to config.txt.
```
[Pulse]
recruiter = pulse
title = Snake game
description = Play a round of the snake game.
pulse_api_url = PAPI_ENDPOINT_URL
pulse_location = http://sws.geonames.org/226074/
pulse_app_id = PULSE_APP_ID
pulse_api_key = PULSE_API_KEY
pulse_page_id = 12345678907891
pulse_link = https://www.istresearch.com/privacy
pulse_image_url = https://avatars1.githubusercontent.com/u/4365304?s=200&v=4
base_payment = 1
```
- Boot dallinger and wait for it to create its campaign.
```
dallinger debug --verbose
```
- Confirm the agents endpoint is successfully accessed and the agent is engaged
```
"POST /dev-jsteele/engage HTTP/1.1" 200 689
 "GET /dev-jsteele/agent?location=http%3A%2F%2Fsws.geonames.org%2F226074%2F HTTP/1.1" 200 3066
11:05:11 AM web.1   |  2018-08-20 11:05:11,836 Got agent a2718ed1-cfc0-48b3-b0d8-4459645955bd
```